### PR TITLE
Zlant: No more just a prototype, stock available

### DIFF
--- a/keyboards/zlant/readme.md
+++ b/keyboards/zlant/readme.md
@@ -5,8 +5,8 @@
 A compact 40% inspired by the Plank with a staggered layout instead.
 
 Keyboard Maintainer: [Felipe Coury](https://github.com/fcoury)  
-Hardware Supported: Zlant Prototype PCB  
-Hardware Availability: Group buy soon
+Hardware Supported: Zlant Prototype PCB to Zlant PCB revision 4
+Hardware Availability: [at 1UP Keyboards](https://www.1upkeyboards.com/shop/keyboard-kits/diy-40-kits/zlant-40-keyboard-kit/)
 
 Make example for this keyboard (after setting up your build environment):
 


### PR DESCRIPTION
## Description

Update hardware documentation of the Zlant:

* It's no more just a prototype with the group buy ahead.
* It's available as stock at 1UP Keyboards. Link to their product page.
* Document, that all revisions up to revision 4 works, too. (I own a Zlant rev. 4 and can confirm that it also works with that revision. Hence it should be save to assume that any intermediate revision works, too.)

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [x] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [x] Documentation

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My (Markdown) code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
